### PR TITLE
Fix eject script.

### DIFF
--- a/packages/inferno-scripts/package.json
+++ b/packages/inferno-scripts/package.json
@@ -56,7 +56,6 @@
     "path-exists": "2.1.0",
     "postcss-loader": "1.0.0",
     "promise": "7.1.1",
-    "react-dev-utils": "^0.3.0",
     "recursive-readdir": "2.1.0",
     "rimraf": "2.5.4",
     "strip-ansi": "3.0.1",

--- a/packages/inferno-scripts/scripts/eject.js
+++ b/packages/inferno-scripts/scripts/eject.js
@@ -10,6 +10,7 @@
 var createJestConfig = require('../utils/createJestConfig');
 var fs = require('fs');
 var path = require('path');
+var prompt = require('../../inferno-dev-utils/prompt');
 var rimrafSync = require('rimraf').sync;
 var spawnSync = require('cross-spawn').sync;
 var chalk = require('chalk');


### PR DESCRIPTION
# About These Changes
* Fixes the `ReferenceError` that was being thrown from packages/inferno-scripts/scripts/eject.js
* Removes the dependency on `react-dev-utils`

## Other Note
I read the contribution guidelines before creating this PR, but I couldn't find any open issues or PR's for your fork.