### PR TITLE
Fixed README.md user guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,28 +99,28 @@ Your app is ready to be deployed!
 
 ## User Guide
 
-The [User Guide](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md) includes information on different topics, such as:
+The [User Guide](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md) includes information on different topics, such as:
 
-- [Updating to New Releases](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#updating-to-new-releases)
-- [Folder Structure](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#folder-structure)
-- [Available Scripts](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#available-scripts)
-- [Displaying Lint Output in the Editor](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#displaying-lint-output-in-the-editor)
-- [Installing a Dependency](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#installing-a-dependency)
-- [Importing a Component](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#importing-a-component)
-- [Adding a Stylesheet](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-a-stylesheet)
-- [Post-Processing CSS](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#post-processing-css)
-- [Adding Images and Fonts](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-images-and-fonts)
-- [Using the `public` Folder](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#using-the-public-folder)
-- [Adding Bootstrap](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-bootstrap)
-- [Adding Flow](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-flow)
-- [Adding Custom Environment Variables](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-custom-environment-variables)
-- [Can I Use Decorators?](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#can-i-use-decorators)
-- [Integrating with a Node Backend](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#integrating-with-a-node-backend)
-- [Proxying API Requests in Development](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#proxying-api-requests-in-development)
-- [Using HTTPS in Development](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#using-https-in-development)
-- [Generating Dynamic `<meta>` Tags on the Server](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#generating-dynamic-meta-tags-on-the-server)
-- [Running Tests](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#running-tests)
-- [Deployment](https://github.com/facebookincubator/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#deployment)
+- [Updating to New Releases](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#updating-to-new-releases)
+- [Folder Structure](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#folder-structure)
+- [Available Scripts](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#available-scripts)
+- [Displaying Lint Output in the Editor](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#displaying-lint-output-in-the-editor)
+- [Installing a Dependency](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#installing-a-dependency)
+- [Importing a Component](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#importing-a-component)
+- [Adding a Stylesheet](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-a-stylesheet)
+- [Post-Processing CSS](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#post-processing-css)
+- [Adding Images and Fonts](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-images-and-fonts)
+- [Using the `public` Folder](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#using-the-public-folder)
+- [Adding Bootstrap](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-bootstrap)
+- [Adding Flow](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-flow)
+- [Adding Custom Environment Variables](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#adding-custom-environment-variables)
+- [Can I Use Decorators?](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#can-i-use-decorators)
+- [Integrating with a Node Backend](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#integrating-with-a-node-backend)
+- [Proxying API Requests in Development](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#proxying-api-requests-in-development)
+- [Using HTTPS in Development](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#using-https-in-development)
+- [Generating Dynamic `<meta>` Tags on the Server](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#generating-dynamic-meta-tags-on-the-server)
+- [Running Tests](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#running-tests)
+- [Deployment](https://github.com/infernojs/create-inferno-app/blob/master/packages/inferno-scripts/template/README.md#deployment)
 
 A copy of the user guide will be created as `README.md` in your project folder.
 


### PR DESCRIPTION
It is just replacing the `facebookincubator` with `infernojs`.

Keep up the good work!