### PR TITLE
Alias react to inferno-compat

### DIFF
--- a/packages/inferno-scripts/config/webpack.config.dev.js
+++ b/packages/inferno-scripts/config/webpack.config.dev.js
@@ -76,6 +76,10 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    alias: {
+      'react': 'inferno-compat',
+      'react-dom': 'inferno-compat'
+    },
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
     // We use `fallback` instead of `root` because we want `node_modules` to "win"

--- a/packages/inferno-scripts/config/webpack.config.prod.js
+++ b/packages/inferno-scripts/config/webpack.config.prod.js
@@ -84,6 +84,10 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    alias: {
+      'react': 'inferno-compat',
+      'react-dom': 'inferno-compat'
+    },
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
     // We use `fallback` instead of `root` because we want `node_modules` to "win"


### PR DESCRIPTION
It's what I proposed at https://github.com/infernojs/create-inferno-app/issues/26
We won't bloat the install by adding inferno-compat, but if one wants to user it then the one should just `yarn add inferno-compat` and it's good to use React libs.