### PR TITLE
Fixes issue #54 - react alias in jest config

### DIFF
--- a/packages/inferno-scripts/scripts/utils/createJestConfig.js
+++ b/packages/inferno-scripts/scripts/utils/createJestConfig.js
@@ -42,6 +42,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleNameMapper: {
       '^inferno-native$': 'inferno-native-web',
+      '^react$': 'inferno-compat',
+      '^react-dom$': 'inferno-compat',
     },
     moduleFileExtensions: ['web.js', 'js', 'json', 'web.jsx', 'jsx'],
   };


### PR DESCRIPTION
This could also be fixed by adding `'moduleNameMapper'` to the `supportedKeys` array on line 54 and then modifying `package.json` to add the alias. I'm fine to update this PR if that would be the preferred approach instead. 