### PR TITLE
Enable jsx-uses-inferno

### DIFF
--- a/packages/eslint-config-inferno-app/index.js
+++ b/packages/eslint-config-inferno-app/index.js
@@ -255,6 +255,7 @@ module.exports = {
         ignore: [],
       },
     ],
+    'inferno/jsx-uses-inferno': 'warn',
     'inferno/jsx-uses-vars': 'warn',
     'inferno/no-danger-with-children': 'warn',
     'inferno/no-direct-mutation-state': 'warn',


### PR DESCRIPTION
Removes eslint no-unused-vars warning for Inferno in every component file. Issue #62